### PR TITLE
`improve-cli-help` review changes for PR #137

### DIFF
--- a/pkg/tsdbctl/add.go
+++ b/pkg/tsdbctl/add.go
@@ -82,7 +82,7 @@ func newAddCommandeer(rootCommandeer *RootCommandeer) *addCommandeer {
 		},
 	}
 
-	cmd.Flags().StringVarP(&commandeer.tArr, "times", "t", "", "time array, comma separated")
+	cmd.Flags().StringVarP(&commandeer.tArr, "times", "m", "", "time array, comma separated")
 	cmd.Flags().StringVarP(&commandeer.vArr, "values", "d", "", "values array, comma separated")
 	cmd.Flags().StringVarP(&commandeer.inFile, "file", "f", "", "CSV input file")
 	cmd.Flags().BoolVar(&commandeer.stdin, "stdin", false, "read from standard input")

--- a/pkg/tsdbctl/create.go
+++ b/pkg/tsdbctl/create.go
@@ -76,7 +76,7 @@ func newCreateCommandeer(rootCommandeer *RootCommandeer) *createCommandeer {
 	cmd.Flags().IntVarP(&commandeer.shardingBuckets, "sharding-buckets", "b", defaultShardingBuckets, "number of buckets to split key")
 	// TODO: enable sample-retention when supported
 	// cmd.Flags().IntVarP(&commandeer.sampleRetention, "sample-retention", "r", defaultSampleRetentionHours, "sample retention in hours")
-	cmd.Flags().StringVar(&commandeer.sampleRate, "rate", defaultIngestionRate, "sample rate")
+	cmd.Flags().StringVarP(&commandeer.sampleRate, "rate", "r", defaultIngestionRate, "sample rate")
 
 	commandeer.cmd = cmd
 

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -67,7 +67,7 @@ func NewRootCommandeer() *RootCommandeer {
 	cmd.PersistentFlags().StringVarP(&commandeer.verbose, "verbose", "v", "", "Verbose output")
 	cmd.PersistentFlags().Lookup("verbose").NoOptDefVal = "debug"
 	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "dbpath", "p", "", "sub path for the TSDB, inside the container")
-	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - username:password@ip:port")
+	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - ip:port")
 	cmd.PersistentFlags().StringVarP(&commandeer.cfgFilePath, "config", "g", "", "path to yaml config file")
 	cmd.PersistentFlags().StringVarP(&commandeer.container, "container", "c", "", "container to use")
 	cmd.PersistentFlags().StringVarP(&commandeer.username, "username", "u", "", "user name")

--- a/pkg/tsdbctl/tsdbctl.go
+++ b/pkg/tsdbctl/tsdbctl.go
@@ -66,12 +66,12 @@ func NewRootCommandeer() *RootCommandeer {
 
 	cmd.PersistentFlags().StringVarP(&commandeer.verbose, "verbose", "v", "", "Verbose output")
 	cmd.PersistentFlags().Lookup("verbose").NoOptDefVal = "debug"
-	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "dbpath", "p", "", "sub path for the TSDB, inside the container")
+	cmd.PersistentFlags().StringVarP(&commandeer.dbPath, "table-path", "t", "", "sub path for the TSDB, inside the container")
 	cmd.PersistentFlags().StringVarP(&commandeer.v3ioPath, "server", "s", defaultV3ioServer, "V3IO Service URL - ip:port")
 	cmd.PersistentFlags().StringVarP(&commandeer.cfgFilePath, "config", "g", "", "path to yaml config file")
 	cmd.PersistentFlags().StringVarP(&commandeer.container, "container", "c", "", "container to use")
 	cmd.PersistentFlags().StringVarP(&commandeer.username, "username", "u", "", "user name")
-	cmd.PersistentFlags().StringVarP(&commandeer.password, "password", "w", "", "password")
+	cmd.PersistentFlags().StringVarP(&commandeer.password, "password", "p", "", "password")
 
 	// add children
 	cmd.AddCommand(


### PR DESCRIPTION
- Global `-s|--server` flag description — remove the reference to including the username and password in the URL (supported now only for backward compatibility).
- Fix bug whereby `-w` was used both for the global password flag and the `add` windows flag"
  - Use `-p` for the password flag.
  - Rename the global table-pah `-p|--dbpath` flag to `-t|--table-path`.
  - Rename the `query` command's times-array short flag from `-t` to `-m`.
- Add a `-r` short flag for the `create` command's `--rate` flag (sample rate).